### PR TITLE
[2022] Explore navigation for iOS, Eliminate data races using Swift Concurrency, Embrace Swift generics

### DIFF
--- a/2022/EliminateDataracesUsingSwiftConcurrency.md
+++ b/2022/EliminateDataracesUsingSwiftConcurrency.md
@@ -1,0 +1,300 @@
+
+# WWDC22 Eliminate data races using Swift Concurrency
+
+> Swift Concurrency 를 이용하여 data races 를 제거해봅시다 !
+
+> 요약 : @Sendable 을 사용해서 
+
+
+## 1 . Task isolation
+
+격리에 대해 이야기 합니다.
+Task란 무엇일까요? Task는 순차적, 비동기적, 독립적으로 동작합니다. 여기선 하나의 Task 를 하나의 보트로 비유해서 설명합니다.  보트들이 완전히 독립적 이라면, 데이터레이스를 걱정할 필요가 없지만, 보트끼리 소통할 방법이 없다면, 그다지 유용하지 않을 겁니다. 
+
+![](https://hackmd.io/_uploads/SkgOfVvw3.png)
+
+
+- 한 보트에서 다른 보트로 파인애플을 옮긴다고 가정해봅시다. 
+```swift
+enum Ripeness {
+    case hard
+    case perfect
+    case mushy(daysPast: Int)
+}
+
+struct Pineapple {
+    var weight: Double
+    var ripeness: Ripeness // 숙성도
+    mutating func rippen() async {...}
+    mutating func slice() -> Int {...}
+}
+```
+- 값타입을 사용하게 되면, 객체를 공유하지 않기 때문에 data race 문제가 일어나지 않습니다. 
+- 이런 특성은 값타입이 isolation을 유지하도록 합니다. (rippen이나slice 메서드를 실행시켜도 원본값에 영향을 미치지 않으니까!)
+- 반면에 이런 치킨 Class 가 있다면 어떨까요? 
+```swift
+class Chicken {
+    let name: String
+    var currentHunger: HungerLevel
+
+    func feed()
+    func play()
+    func produce() -> Egg {...}
+}
+```
+![](https://hackmd.io/_uploads/BkCiM4wwh.png)
+
+
+- 위와 같이 참조타입을 이용할 경우 한 보트에서 다른보트로 이동시킨 후, 각각의 보트에서 다른 메서드를 동시성으로 실행한다면 독립적이지 않게 됩니다. 
+- 치킨 = shared mutable data (가변 공유 데이터) 입니다. 가변공유 데이터는 데이터레이스를 발생시킬 위험이 있습니다. 그래서 보트에서 다른보트로 치킨이 공유되지 않는지 확인하는 방법이 필요합니다. 
+
+### Sendable
+
+> Sendable 프로토콜은 데이터레이스를 발생시키지 않고 서로 다른 격리 도메인 간에 안전하게 공유할 수 있습니다.
+
+
+![](https://hackmd.io/_uploads/BkkafEvwh.png)
+
+
+- 위처럼 채택을 해보면 알 수 있습니다. Sendable 프로토콜이 채택 가능해야 데이터레이스를 발생시키지 않는다는 것을 보장할 수 있습니다. 
+- 클래스는 참조타입 이기에, final class 에 불변 상수만 가지는 상태가 아닌 이상 sendable 할 수 없습니다. 
+- 아래의 경우 Sendable 채택이 가능하지만
+
+```swift
+final class Chicken: Sendable {
+    let name: String
+}
+```
+
+```swift 
+final class Chicken: Sendable {
+    let name: String
+    var birthDay: String // 가변상태 감지로 인한 오류발생
+}
+```
+
+- @unchecked Sendable 를 이용하여 컴파일 타임에 진행되는 Sendable 검사를 건너뛸 수 있습니다. 다만, 안전보장이 되지 않으므로 주의해서 사용해야 합니다.
+- 아래와 같이 함수의 타입에서도 Sendable 속성을 사용해줄 수 있습니다.  
+![](https://hackmd.io/_uploads/ryOAGEvwh.png)
+
+- 일반적으로 함수 유형은 프로토콜을 준수할 수 없습니다.
+
+## 2. Actor
+> Actor 를 이용해 가변상태를 격리시킬 수 있습니다. 
+
+
+```swift
+actor Island {
+    var flock: [Chicken]
+    var food: [Pineapple]
+
+    func advanceTime()
+}
+```
+
+- 위 코드로 구현된 섬은 동시성의 바다 위에서 각각 독립적인 상태를 가집니다. 
+- 보트로 하나의 섬으로 가서 위 advanceTime() 메서드를 실행시킬 수 있습니다.
+- actor 에는 한번에 하나의 보트만 접근 가능합니다.
+```swift
+func nextRound(islands: [Island]) async {
+    for island in islands {
+        await island.advanceTime()
+    }
+}
+```
+
+- 보트(Task) 와 섬(actor) 는 마찬가지로 가변데이터를 공유할 수 없고, Sendable 한 데이터만 공유 가능합니다. 
+- Actor 는 참조타입 이지만, 모든 속성과 코드를 격리하여 동시 엑세스를 방지합니다. 
+- 모든 Actor 타입은 암묵적으로  Sendable 합니다.
+
+```swift
+
+await myIsland.addToFlock(myChicken) // 불가능
+myChicken = await myIsland.adoptPet() // 불가능
+
+```
+
+
+- 어떤 코드가 Actor에 의해 격리되어 있고 어떤 코드가 그렇지 않은지 어떻게 알 수 있을까요?
+
+```swift
+
+actor Island {
+    var flock: [Chicken]
+    var food: [Pineapple]
+    func advenceTime() {
+        let totalSlices = food.indices.reduce(0) { (total, nextIndex) in
+            total + food[nextIndex].slice()
+        }
+    
+        Task {
+            flock.map(Chicken.produce)
+        } // actor 격리를 상속한다. 
+    
+        Task.detached {
+            let ripePineapples = await food.filter { $0.ripeness == .perfect }
+            // 격리된 food를 참조하려고 await 을 사용하고 있다. 
+            print("There are \(ripePineapples.count) ripe pineapples")
+        } // 맥락에서 actor 격리를 상속하지 않는다. 독립적이기 때문, actor 외부에 있는 것으로 간주
+        // 위 클로저를 non-isolated code 라 부른다. 
+    }
+}
+```
+
+- actor의 격리는 맥락에 따라 결정됩니다.  (이 부분 이해 불가)
+
+#### non-isolated
+
+```swift
+extension Island {
+    func meetTheFlock() {
+        let flockNames = flock.map { $0.name }
+        print("Meet our fabulous flock: \(flockNames)")
+    }
+}
+```
+
+- 어떤 actor 에게도 실행되지 않는 메서드를 말합니다. 
+- 이 키워드를 사용하여 actor 외부에 배치하면, actor 내부의 기능을 명시적으로 `nonisolated` 키워드를 이용하여 비격리로 만들 수 있습니다. 
+```swift
+extension Island {
+    nonisolated func meetTheFlock() {
+        let flockNames = await flock.map { $0.name }
+        print("Meet our fabulous flock: \(flockNames)")
+    }
+}
+```
+
+- 비격리 코드 예시를 하나 더 보겠습니다. 
+
+```swift
+func greet(_ friend: Chicken) { }
+
+// 비격리, 동기 
+extension Island {
+    func greetOne() {
+        if let friend = flock.randomElement() {
+            greet(friend)
+        }
+    }
+}
+
+
+----
+
+// 비격리, 비동기
+func greetAny(flock: [Chicken]) async {
+    if let friend = flock.randomElement() {
+        greet(friend)
+    }
+}
+```
+
+
+### @MainActor
+
+- 사용예시
+```swift
+@MainActor func updateView() {}
+
+Task { @MainActor in
+    // ..
+    view.selectedChicken = lily
+}
+
+nonisolated func computeAndUpdate() async {
+    computeNewValues()
+    await updateView() // 이처럼 MainActor와 격리되지 않은 맥락에서 updateView를 호출하는
+     //경우 MainActor로의 전환을 설명하기 위한 await 키워드를 사용해야 합니다. 
+}
+
+
+@MainActor
+class ChickenValley {
+    var flock: [Chicken]
+    var food: [Pineapple]
+    
+    func advanceTime() {
+        for chicken in flock {
+            chicken.eat(from: &food)
+        }
+    }
+}
+```
+
+## 3. Atomicity
+>  원자성 
+
+Swift Concurrency의 목적은 데이터레이스를 제거하는 것입니다. 
+actor 는 한 번에 하나의 작업만 수행합니다. 하지만 actor에 대한 실행을 중지하면 해당 actor는 다른 작업을 실행할 수 있습니다. 이렇게 하면 프로그램이 `진행` 되므로 교착 상태의 가능성이 제거됩니다. 
+
+그러나 await 구문에 대한 actor의 불변을 고려해야 합니다. 
+
+```swift
+func deposit(pineapples: [Pineapple], onto island: Island) async {
+    var food = await island.food
+    food += pineapples
+    await island.food = food // 같은 actor 에 대놓고 접근하는 상황 -> 컴파일러가 오류 방출
+}
+
+// 위 코드는 오류를 발생
+
+extension Island {
+    func deposit(pineapples: [Pineapple]) {
+        var food = self.food
+        food += pineapples
+        self.food = food
+    }
+}
+
+// 이렇게 하면 동기 코드 이므로, 중단 없이 actor 에서 실행된다. 
+
+// 비동기 actor의 경우 간단하게 유지하자. 주로 동기식 트랜잭션 작업으로 구성하고 각 await 작업시 actor 상태가 양호하도록 주의해야 한다. 
+
+```
+
+
+- 같은 actor의 상태에 접근하려는 2개의 await 사이에서 변하지 않는다고 가정했지만, await 은 다른 우선 순위가 높은 일을 하는 동안 우리 작업이 여기서 보류될 수도 있습니다. 
+
+
+## 4. Ordering
+> 동시성 프로그램에서는 여러가지 일들이 동시에 발생하므로, 이러한 일들이 일어나는 순서는 실행마다 다를 수 있습니다. 
+
+- actor는 작업 순서를 지정하기 위한 도구가 아닙니다.
+- actor 는 우선순위가 높은 작업 먼저 실행합니다. 우선순위가 낮은 작업이 동일한 actor 에서 우선순위가 높은 작업보다 먼저 발생하는 우선 순위 역전이 제거된다.  (직렬큐 FIFO 와는 상당한 차이가 있다. )
+- Swift Concurrency 에는 작업 순서를 정하기 위한 몇몇 도구가 있습니다.
+    - Task
+    - AsyncStreams - 순서를 유지하면서도 스트림에 요소를 추가할 수 있는 이벤트와 생성자와 공유 가능하다.
+     ```swift
+        for await event in eventStream {
+            await process(event)
+        } 
+    ```
+
+- Swift 5.7 부터 Swift 컴파일러가 얼마나 엄격하게 Sendable을 검사해야 하는지 지정하는 빌드 설정을 도입했습니다. 
+
+![](https://hackmd.io/_uploads/HJalmEwwn.png)
+
+- 원래는 Sendable 을 채택해봄으로써 이 객체가 Sendable 한지 확인할 수 있었다면, 저 검사를 강력하게 하도록 설정하면 Sendable을 채택해보지 않고도 알아서 경고를 띄워주는 방식입니다. 
+- 기존에 만들어놨던 모듈에 이러한 새로운 검사가 적용되어 불편한 경우도 있을텐데, 그럴 땐
+```swift
+
+@preconcurrency import FarmAnimals // @preconcurrency 키워드를 붙여주면 경고를 비활성화 해준다. 
+
+func visit(coop: Coop) async {
+    guard let favorite = coop.flock.randomElement() else {
+        return
+    }
+    Task {
+        favorite.play()    
+    }
+}
+
+```
+
+- Complete checking 을 이용해 모든 data race 를 제거할 수 있습니다.
+- 이전 방식에서는 모든 항목을 검사하지만, 여기서는 모든 코드에 대해 검사를 수행합니다. 
+- 점진적으로 엄격한 검사를 이어나가며 코드에서 오류 클래스를 제거합시다 !
+
+## Reference
+-   [Eliminate data races using Swift Concurrency](https://developer.apple.com/videos/play/wwdc2022/110351/)

--- a/2022/EmbraceSwift generics.md
+++ b/2022/EmbraceSwift generics.md
@@ -1,0 +1,220 @@
+
+# WWDC22 Embrace Swift generics
+
+- Model with concrete types
+- Identify common capabilities
+- Build an interface
+- Write generic code
+
+위 네가지 단계로 분리하여 농장 시뮬레이션을 위한 Generic 코드를 작성 해보겠습니다. 
+
+### 1. Model with concrete types
+
+```swift
+
+struct Cow {
+    func eat(_ food: Hay) {...}
+}
+
+struct Hay { // 건초
+    static func grow() -> Alfafa {...}
+}
+
+struct Alfafa {
+    func harvest() -> Hay {...}
+}
+
+struct Farm {
+    func feed(_ animal: Cow) {
+        let alfafa = Hay.grow()
+        let hay = alfafa.harvest()
+        animal.eat(hay)
+    }
+}
+```
+
+소에게 먹이를 줄 수 있게 되었습니다. 
+
+⚠️ 하지만 말, 닭 같은 동물 유형을 더 추가하고 싶은 경우 어떻게 해야할까요? 
+
+각각의 동물 타입을 만들어 농장에서 각각의 동물에게 feed 해주는 메서드를 overload를 통해 완성할 수 있습니다.
+
+<img src="https://hackmd.io/_uploads/ByWq74vD3.png" width=400>
+
+하지만 이 방법은 boilerplate 코드를 생성시키고 가독성이 좋지 않게 변합니다. 
+이때 필요한 것이 일반화(Generalize) 입니다.
+
+### 2. Identify common capabilities
+> 동물간 공통적인 기능을 식별합니다. 
+
+- 추상화 코드를 작성하고, 추상을 받는 구체타입에서 각각 다르게 동작하도록 구현하려고 합니다. 
+- 이를 다형성이라고 부릅니다. 
+- 여러가지 다형성
+    - 1. 오버로드 = 함수가 받는 인수에 따라 함수의 기능이 달라집니다. (Ad-hoc 다형성이라고 부름)
+    - 2. 서브타입 = 클래스 상속을 통해 부모타입의 특성을 물려받아 각기 다르게 기능할 수 있습니다. 
+    - 3. 제네릭 
+![](https://hackmd.io/_uploads/SkzTQVDw3.png)
+
+- 위처럼 클래스를 이용해 다형성을 만들 수 있습니다. 그러나 as? 구문을 이용해 런타임에서야 구체타입을 확인할 수 있고. 이는 좋지 않은 흐름인 것 같습니다. 
+```swift
+
+class Animal<Food> {
+    func eat(_ food: Food) {...}
+}
+
+class Cow: Animal<Hay> {}
+
+class Horse: Animal<Carrot> {}
+
+class Chicken: Animal<Grain> {}
+
+```
+- 이런식으로 Animal에 제네릭타입을 받도록 설정할 수 있지만, 꺽새 안에 각 동물이 소비하는 음식 타입을 하나하나 다 입력해주어야 하죠. 또 동물마다의 다른 타입의 어떤 것이 들어와야 한다면 꺽새 안에 들어갈 타입은 더 많아질 것입니다. 
+
+### 3. Build an interface
+
+- Animal 의 공통 능력을 추려봅시다. 
+    - 특정타입의 음식
+    - 음식을 소비하는 작업
+- 우리는 위 같은 기능을 나타내는 인터페이스를 구축할 수 있습니다. 바로 프로토콜을 사용하는 것입니다. 
+```swift
+protocol Animal {
+    associatedtype Feed: AnimalFeed
+    func eat(_ food: Feed)
+}
+
+struct Cow: Animal {
+    func eat(_ food: Hay) {...}
+}
+
+struct Horse: Animal {
+    func eat(_ food: Carrot) {...}
+}
+
+struct Chicken: Animal {
+    func eat(_ food: Grain) {...}
+}
+```
+
+- 이제 제네릭 코드를 작성할 수 있습니다. 
+
+### 4. Write generic code
+
+```swift
+protocol Animal {
+    associatedtype Feed: AnimalFeed
+    func eat(_ food: Feed)
+}
+
+struct Farm {
+    func feed<A: Animal>(_ animal: A) {...}
+}
+
+// or
+
+struct Farm {
+    func feed<A>(_ animal: A) where A: Animal {...} // 복잡해 보인다. 
+}
+
+// 간단하게 표현하는 방법이 있다!
+
+struct Farm {
+    func feed(_ animal: some Animal) // 짠.
+}
+
+```
+
+#### `some` 구문에 대하여
+- `some Animal ` 에 들어올 타입은 Animal을 채택하고 있는 특정 타입입니다. 
+- SwiftUI 에서 사용중인 `var body: some View` 에서의 some 과 같은 것입니다. 
+- `some View` 에는 View 를 채택하는 어떤 타입이 들어올 것이지만, 구체적으로 어떤 타입인지는 알 필요 없습니다. 
+
+#### 추상화 개념
+- 특정 구체타입의 플레이스 홀더를 나타내는 추상 타입을 `Opaque Type` 이라고 합니다. 
+- 대체되는  특정 구체타입을 `Underlying Type` (기본타입) 이라고 합니다. 
+- Opaque 타입의 값이 사용되는 범위에서는 하나의 기본타입으로 고정이 됩니다. 
+- 이렇게 되면 값을 엑세스 할 때마다 동일한 기본타입을 얻을 수 있습니다. (예시코드가 이따 나옴)
+
+```swift
+let animal: some Animal = Horse() // 1.이때는 animal의 타입이 Horse라고 타입추론이 됩니다.
+animal = Chicken() // 기본타입이 고정 되어있기 때문에 이 경우 에러가 난다.
+
+func feed(_ animal: some Animal) // 2. 파라미터로 Opaque타입이 이용될 때.
+feed(Horse()) // feed 안에서 사용되는 animal 파라미터의 타입은 여기서 타입추론이 됩니다. 
+feed(Chicken()) // 각 함수 scope 에서만 고정되면 되므로 이 경우 에러가 나지 않습니다. 
+// 매개변수에서 사용하는 some 타입은 Swift 5.7의 신기능 입니다.
+
+func makeView(for farm: Farm) -> some View { // 3.결과값으로 Opaque타입이 이용될 때.
+    FarmView(farm) // 반환값에서 some View의 타입추론이 됩니다. 
+}
+// 프로그램의 모든 위치에서 호출할 수 있으므로 결과타입의 범위는 전역적입니다. 
+// 그러므로 기본타입 고정이 되어야 합니다. 
+
+func makeView(for farm: Farm) -> some View {
+    if condition {
+        return FarmView(farm)
+    } else {
+        return EmptyView()
+    }
+}
+// 위 코드는 에러가 납니다. 위 경우는 함수에 @ViewBuilder 어트리뷰트를 붙여주어 (ViewBuilderDSL)
+// 문제를 해결할 수 있습니다.
+
+@ViewBuilder
+func makeView(for farm: Farm) -> some View {
+    if condition {
+        FarmView(farm)
+    } else {
+        EmptyView()
+    }
+}
+
+```
+
+다시 농장으로 돌아와 Opaque 타입을 이용해 코드를 작성해보겠습니다.
+
+```swift
+protocol Animal {
+    associatedtype Feed: AnimalFeed
+    func eat(_ food: Feed)
+}
+
+struct Farm {
+    func feed(_ animal: some Animal) {
+        let crop = type(of: animal).Feed.grow()
+        let produce = crop.harvest()
+        animal.eat(produce)
+    } 
+    // 위 함수 범위 내에서 animal의 타입은 기본타입 고정되어있기 때문에 
+    // 컴파일타임에 타입간 관계를 알고 있습니다. 
+
+    func feedAll(_ animals: [???]) {}
+}
+```
+- feedAll() 메서드를 구현하기 위해 들어가야 될 파라미터 타입은 뭘까요?
+![](https://hackmd.io/_uploads/rJ8kV4DDh.png)
+- 배열에서 some 키워드를 이용하면 이런식으로 동작 할 것입니다. 
+- 이 때 사용할 수 있는 키워드가 `any` 입니다. any 키워드를 이용하면 런타임에 기본타입이 달라질 수 있음을 나타냅니다. 
+- any 키워드를 사용하게 되면 정적 타입은 같지만 동적 타입이 달라집니다. 동적 타입은 런타임에만 알 수 있습니다. 
+
+```swift
+struct Farm {
+    func feed(_ animal: some Animal) {
+        let crop = type(of: animal).Feed.grow()
+        let produce = crop.harvest()
+        animal.eat(produce)
+    } 
+    
+    func feedAll(_ animals: [any Animal]) { // any 키워드를 사용합니다.
+        for animal in animals {
+            //animal.eat() // 컴파일 에러가 납니다. 
+            feed(animal) // animal 이 some Animal 로써 주입되기 때문에 안전하게 동작합니다.
+        }
+    }
+}
+```
+
+- some 키워드를 이용하면 기본타입이 고정됩니다. 
+- any 키워드를 이용하면 type erase(타입 소거) 를 제공합니다. 
+    - type erase가 궁금하면 WWDC: Design protocol interfaces in Swift 를 참고해보세요.
+- 변환이 필요하다는 걸 알 때까지 기본값으로 let-constant를 작성하는 것과 유사합니다. 

--- a/2022/ExploreNavigationForiOS.md
+++ b/2022/ExploreNavigationForiOS.md
@@ -1,0 +1,72 @@
+# [WWDC22] Explore navigation for iOS
+
+> 사용자에게 친숙한 네비게이션 경험을 제공하는 것은 매우 중요합니다. 
+
+## 1. Tab bars 
+> 앱의 콘텐츠를 여러 섹션으로 분류해줍니다. 
+
+- Use tabs to reflect your information hierarchy
+- Balance features throughout tabs
+- Avoid duplicating functionality into a single tab
+- Keep tabs persistent throughout your app
+- Use clear and concise labels
+
+- 탭들 전반에 기능을 분배해서 인터페이스의 균형을 만들어 보세요.
+
+    <img src="https://i.imgur.com/FpblQO6.png" width="200">
+    <img src="https://i.imgur.com/OtzTvnN.png" width="200">
+
+- 일부 기능들이 발견되지 못하고 사용자에 의해 사용되지 않을 수 있다는 염려에서 홈탭에 모든 기능을 꾸겨넣는 것은 좋지 않습니다. 
+- symbol을 통해 탭의 의도를 한 눈에 알아볼 수 있도록 만들어 보세요.
+
+## 2. Hierarchical navigation
+> 높은 수준에서 더욱 세부적인 사항으로 파고들며 콘텐츠를 통과하며 이동하는 걸 문자 그대로 표현한 것입니다. 
+
+- To traverse your app's hierarchy
+- Keep the tab bar anchored to the bottom of the screen!!
+- Use the navigation bar to orient people 
+- Use with a disclosure indicator
+- When navigating frequently between content
+
+- 탭바가 있는 경우, 네비게이션 이동을 할 때 사라지지 않게 만들어야 합니다. 
+- 네비게이션 이동을 한다고 표현할 수 있는 방법으로 disclosure indicator 가 있습니다. 
+    <img src="https://i.imgur.com/G9o4twT.png" width="400">
+- 아랍권 같은 곳은 반대로 구현합니다.
+    <img src="https://i.imgur.com/cfSbPC9.png" width="400">
+- 자주 화면전환이 일어난다고 생각되는 곳에서 Navigation을 이용하세요.
+    - 카톡 채팅창 목록 -> 채팅창 화면전환 처럼 빈번히 일어나는 곳에 모달로 구현되어 있다면 왔다갔다 하는 작업이 힘들 것입니다. 
+
+## 3. Modal presentations
+> 앱의 계층을 횡단하고 뷰 사이를 전환하는 방법 중 침해가 없고 친숙한 방법입니다. 
+
+- Present from the bottom of the screen
+- Use for a simple task, multi-step, or full screen
+- Dissmiss a modal with `cancel` and preferred actions
+- Use close for minimal interaction
+- Limit modals over modals
+
+- 자립적인 작업이란? 
+    - simple task (집중력↑, 실수로 다른 탭 눌러 흐름에서 벗어날 걱정 x)
+    <img src="https://i.imgur.com/UW1hjCy.gif" width="300">
+    
+    - multi step (복잡한 작업에 모달 쓴다고 안좋다? x 목적은 집중력 강화)
+    <img src="https://i.imgur.com/cHjJtDl.gif" width="300">
+    
+    - full screen
+    <img src="https://i.imgur.com/HjqX24g.gif" width="300">
+ 
+- 네비게이션 바에서 백버튼이 중요하듯이 모달에서도 cancel 버튼이 중요합니다. 
+- 우측의 Add 버튼처럼 선호하는 동작을 의도한 경우 중요성 강조를 위해 굵은 폰트로 나타냅니다. 
+    - 위 Add 버튼의 경우 모달에 여전히 입력이 없거나 상호작용이 없다면 비활성화를 시켜두어 입력이 필요하다는 것을 분명하게 알려줄 수 있습니다. 
+    <img src="https://i.imgur.com/BhiEfR6.png" width="300">
+    - cancel 탭시, 만약 입력이 있었다면 작업내역을 잃을 수 있다는 경고를 ActionSheet를 통해 알려줄 수 있습니다. 만약 작업내역이 없다면 cancel 시 바로 화면이 dismiss 될 것입니다. 
+    <img src="https://i.imgur.com/cD3w1sM.png" width="300">
+- X 버튼 (사용자의 입력이 필요하지 않을 때만 사용합니다.)
+    <img src="https://i.imgur.com/Szv0d3l.png" width="300">
+- X 버튼 사용의 잘못된 예시. ( x를 누르면 저장되는 것인가? 헷갈린다)
+    <img src="https://i.imgur.com/ENm2HH0.png" width="300">
+
+- 모달 위의 모달을 띄우는 것을 제한합니다.(다만, 모달 뷰 위의 사진추가를 위한 photo picker를 띄우는 것은 예외)
+
+## References
+- [WWDC22 Explore navigation for iOS](https://developer.apple.com/wwdc22/10001 )


### PR DESCRIPTION
# WWDC

- ## [Explore navigation for iOS](https://developer.apple.com/wwdc22/10001)
- ## [Eliminate data races using Swift Concurrency](https://developer.apple.com/videos/play/wwdc2022/110351/)
- ## [Embrace Swift generics](https://developer.apple.com/videos/play/wwdc2022/110352/)

> 밀렸던 3개의 발표자료 한꺼번에 제출합니다 😅